### PR TITLE
Make it work with OS X

### DIFF
--- a/remap.sh
+++ b/remap.sh
@@ -21,6 +21,13 @@ if [ ! -f  "$jarpath.jar" ]; then
     fi
 fi
 
+# OS X doesn't have md5sum, just md5 -r
+if [[ "$OSTYPE" == "darwin"* ]]; then
+   shopt -s expand_aliases
+   alias md5sum='md5 -r'
+   echo "Using an alias for md5sum on OS X"
+fi
+
 checksum=$(md5sum "$jarpath.jar" | cut -d ' ' -f 1)
 if [ "$checksum" != "$minecrafthash" ]; then
     echo "The MD5 checksum of the downloaded server jar does not match the BuildData hash."


### PR DESCRIPTION
Quick fix to make remap.sh work on OS X.

sed still complains about invalid command code z in init.sh, but seems to have no effect.
```sed: 1: "/Users/zach/Spigot/work ...": invalid command code z```

Full log here, https://gist.github.com/Zbob750/082c3bf722338afae07b

